### PR TITLE
Fix typo (Ceritificate -> Certificate)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -21,8 +21,8 @@ pub struct Config {
     ///
     /// The interval is in seconds. A value of 0 disables this feature.
     pub keep_alive_interval: Option<u32>,
-    /// Path to our TLS Certificate. This file must contain `SerialisableCeritificate` as content
-    pub our_complete_cert: Option<SerialisableCeritificate>,
+    /// Path to our TLS Certificate. This file must contain `SerialisableCertificate` as content
+    pub our_complete_cert: Option<SerialisableCertificate>,
 }
 
 impl Config {
@@ -46,12 +46,12 @@ impl Config {
 /// To be used to read and write our certificate and private key to disk esp. as a part of our
 /// configuration file
 #[derive(Serialize, Deserialize, Clone)]
-pub struct SerialisableCeritificate {
+pub struct SerialisableCertificate {
     pub cert_der: Vec<u8>,
     pub key_der: Vec<u8>,
 }
 
-impl SerialisableCeritificate {
+impl SerialisableCertificate {
     // TODO do proper error handling
     pub fn obtain_priv_key_and_cert(&self) -> (quinn::PrivateKey, quinn::Certificate) {
         (
@@ -61,7 +61,7 @@ impl SerialisableCeritificate {
     }
 }
 
-impl Default for SerialisableCeritificate {
+impl Default for SerialisableCertificate {
     fn default() -> Self {
         let cert = rcgen::generate_simple_self_signed(vec!["MaidSAFE.net".to_string()]);
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,4 +1,4 @@
-use crate::config::SerialisableCeritificate;
+use crate::config::SerialisableCertificate;
 use crate::event::Event;
 use crate::wire_msg::WireMsg;
 use std::cell::RefCell;
@@ -71,7 +71,7 @@ pub struct Context {
     pub event_tx: Sender<Event>,
     pub connections: HashMap<SocketAddr, Connection>,
     pub our_ext_addr_tx: Option<Sender<SocketAddr>>,
-    pub our_complete_cert: SerialisableCeritificate,
+    pub our_complete_cert: SerialisableCertificate,
     pub max_msg_size_allowed: usize,
     pub idle_timeout: u64,
     pub keep_alive_interval: u32,
@@ -81,7 +81,7 @@ pub struct Context {
 impl Context {
     pub fn new(
         event_tx: Sender<Event>,
-        our_complete_cert: SerialisableCeritificate,
+        our_complete_cert: SerialisableCertificate,
         max_msg_size_allowed: usize,
         idle_timeout: u64,
         keep_alive_interval: u32,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@ extern crate serde_derive;
 #[macro_use]
 extern crate unwrap;
 
-pub use config::{Config, SerialisableCeritificate};
+pub use config::{Config, SerialisableCertificate};
 pub use error::Error;
 pub use event::Event;
 
@@ -231,7 +231,7 @@ impl Crust {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::{Config, SerialisableCeritificate};
+    use crate::config::{Config, SerialisableCertificate};
     use std::net::SocketAddr;
     use std::str::FromStr;
     use std::sync::mpsc;
@@ -264,7 +264,7 @@ mod tests {
     fn test_multistreaming(should_connect: bool, crust0_port: u16, crust1_port: u16) {
         let (tx0, rx0) = mpsc::channel();
         let (mut crust0, crust0_cert_der) = {
-            let our_complete_cert = SerialisableCeritificate::default();
+            let our_complete_cert = SerialisableCertificate::default();
             let cert_der = our_complete_cert.cert_der.clone();
 
             let mut cfg: Config = Default::default();
@@ -275,7 +275,7 @@ mod tests {
         };
 
         let crust0_info = CrustInfo {
-            peer_addr: unwrap!(SocketAddr::from_str(&format!("127.0.0.1:{}", crust0_port))),
+            peer_addr: unwrap!(format!("127.0.0.1:{}", crust0_port).parse()),
             peer_cert_der: crust0_cert_der,
         };
         let crust0_addr = crust0_info.peer_addr;


### PR DESCRIPTION
Also simplify parsing `SocketAddr` from string