### PR TITLE
Fix tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["ustulation <ustulation@gmail.com>"]
 edition = "2018"
 
 [dependencies]
-quinn = { path = "../quinn/quinn" }
+quinn = { git = "https://github.com/djc/quinn", rev = "cada5cc" }
 tokio = "*"
 unwrap = "*"
 bincode = "*"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -305,8 +305,8 @@ mod tests {
         let crust0_addr = crust0_info.peer_addr;
         let crust1_addr = crust1_info.peer_addr;
 
-        // 400 MiB message
-        let big_msg_to_crust0 = vec![255; 400 * 1024 * 1024];
+        // 10 MiB message
+        let big_msg_to_crust0 = vec![255; 10 * 1024 * 1024];
         let big_msg_to_crust0_clone = big_msg_to_crust0.clone();
 
         // very small messages


### PR DESCRIPTION
Reduces test data size.

We used to send 400 MB of data. This data would be serialized before put
on the wire. Serialization process consumes a lot of CPU which blocks
event loop thread.  If blocked for too long, it result in remote stream
timeouts. Reducing test data to 10 MB makes serialization faster and
avoids mentioned problems and makes the tests pass.