### PR TITLE
Update to latest quinn

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["ustulation <ustulation@gmail.com>"]
 edition = "2018"
 
 [dependencies]
-quinn = { git = "https://github.com/djc/quinn", rev = "e9b9a38" }
+quinn = { git = "https://github.com/djc/quinn", rev = "856b2f5" }
 tokio = "*"
 unwrap = "*"
 bincode = "1.1.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["ustulation <ustulation@gmail.com>"]
 edition = "2018"
 
 [dependencies]
-quinn = { git = "https://github.com/djc/quinn", rev = "e784fe6" }
+quinn = { git = "https://github.com/djc/quinn", rev = "e9b9a38" }
 tokio = "*"
 unwrap = "*"
 bincode = "1.1.2"

--- a/src/config.rs
+++ b/src/config.rs
@@ -17,13 +17,13 @@ pub struct Config {
     /// If we hear nothing from the peer in the given interval we declare it offline to us. If none
     /// supplied we'll default to the documented constant.
     ///
-    /// The interval is in seconds. A value of 0 disables this feature.
-    pub idle_timeout: Option<u64>,
+    /// The interval is in milliseconds. A value of 0 disables this feature.
+    pub idle_timeout_msec: Option<u64>,
     /// Interval to send keep-alives if we are idling so that the peer does not disconnect from us
     /// declaring us offline. If none is supplied we'll default to the documented constant.
     ///
-    /// The interval is in seconds. A value of 0 disables this feature.
-    pub keep_alive_interval: Option<u32>,
+    /// The interval is in milliseconds. A value of 0 disables this feature.
+    pub keep_alive_interval_msec: Option<u32>,
     /// Path to our TLS Certificate. This file must contain `SerialisableCertificate` as content
     pub our_complete_cert: Option<SerialisableCertificate>,
 }
@@ -40,8 +40,8 @@ impl Config {
             port: Default::default(),
             ip: Default::default(),
             max_msg_size_allowed: Default::default(),
-            idle_timeout: Default::default(),
-            keep_alive_interval: Default::default(),
+            idle_timeout_msec: Default::default(),
+            keep_alive_interval_msec: Default::default(),
             our_complete_cert: Some(Default::default()),
         }
     }

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -25,8 +25,8 @@ pub fn connect_to(peer_info: CrustInfo, send_after_connect: Option<WireMsg>) -> 
         let transport_config = unwrap!(Arc::get_mut(&mut peer_cfg.transport));
         // TODO test that this is sent only over the uni-stream to the peer not on the uni
         // stream from the peer
-        transport_config.idle_timeout = ctx(|c| c.idle_timeout);
-        transport_config.keep_alive_interval = ctx(|c| c.keep_alive_interval);
+        transport_config.idle_timeout = ctx(|c| c.idle_timeout) * 1000;
+        transport_config.keep_alive_interval = ctx(|c| c.keep_alive_interval) * 1000;
 
         peer_cfg
     };

--- a/src/connect.rs
+++ b/src/connect.rs
@@ -25,8 +25,8 @@ pub fn connect_to(peer_info: CrustInfo, send_after_connect: Option<WireMsg>) -> 
         let transport_config = unwrap!(Arc::get_mut(&mut peer_cfg.transport));
         // TODO test that this is sent only over the uni-stream to the peer not on the uni
         // stream from the peer
-        transport_config.idle_timeout = ctx(|c| c.idle_timeout) * 1000;
-        transport_config.keep_alive_interval = ctx(|c| c.keep_alive_interval) * 1000;
+        transport_config.idle_timeout = ctx(|c| c.idle_timeout_msec);
+        transport_config.keep_alive_interval = ctx(|c| c.keep_alive_interval_msec);
 
         peer_cfg
     };

--- a/src/context.rs
+++ b/src/context.rs
@@ -73,8 +73,8 @@ pub struct Context {
     pub our_ext_addr_tx: Option<Sender<SocketAddr>>,
     pub our_complete_cert: SerialisableCertificate,
     pub max_msg_size_allowed: usize,
-    pub idle_timeout: u64,
-    pub keep_alive_interval: u32,
+    pub idle_timeout_msec: u64,
+    pub keep_alive_interval_msec: u32,
     quic_ep: quinn::Endpoint,
 }
 
@@ -83,8 +83,8 @@ impl Context {
         event_tx: Sender<Event>,
         our_complete_cert: SerialisableCertificate,
         max_msg_size_allowed: usize,
-        idle_timeout: u64,
-        keep_alive_interval: u32,
+        idle_timeout_msec: u64,
+        keep_alive_interval_msec: u32,
         quic_ep: quinn::Endpoint,
     ) -> Self {
         Self {
@@ -93,8 +93,8 @@ impl Context {
             our_ext_addr_tx: Default::default(),
             our_complete_cert,
             max_msg_size_allowed,
-            idle_timeout,
-            keep_alive_interval,
+            idle_timeout_msec,
+            keep_alive_interval_msec,
             quic_ep,
         }
     }

--- a/src/context.rs
+++ b/src/context.rs
@@ -208,7 +208,7 @@ impl fmt::Debug for ToPeer {
 impl Drop for ToPeer {
     fn drop(&mut self) {
         if let ToPeer::Established { ref q_conn, .. } = *self {
-            q_conn.close(0, &[0; 0]);
+            q_conn.clone().close(0, &[]);
         }
     }
 }
@@ -268,7 +268,7 @@ impl fmt::Debug for FromPeer {
 impl Drop for FromPeer {
     fn drop(&mut self) {
         if let FromPeer::Established { ref q_conn, .. } = *self {
-            q_conn.close(0, &[0; 0]);
+            q_conn.clone().close(0, &[]);
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,8 +124,8 @@ impl Crust {
                 let transport_config = unwrap!(Arc::get_mut(&mut our_cfg.transport_config));
                 // TODO test that this is sent only over the uni-stream to the peer not on the uni
                 // stream from the peer
-                transport_config.idle_timeout = idle_timeout;
-                transport_config.keep_alive_interval = keep_alive_interval;
+                transport_config.idle_timeout = idle_timeout * 1000;
+                transport_config.keep_alive_interval = keep_alive_interval * 1000;
             }
 
             let mut ep_builder = quinn::Endpoint::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,7 +130,7 @@ impl Crust {
 
             let mut ep_builder = quinn::Endpoint::new();
             ep_builder.listen(our_cfg);
-            let (ep, dr, incoming_connections) = unwrap!(ep_builder.bind(&(ip, port)));
+            let (dr, ep, incoming_connections) = unwrap!(ep_builder.bind(&(ip, port)));
 
             let ctx = Context::new(
                 tx,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,13 +38,13 @@ pub const DEFAULT_MAX_ALLOWED_MSG_SIZE: usize = 500 * 1024 * 1024; // 500MiB
 /// This is based on average time in which routers would close the UDP mapping to the peer if they
 /// see no conversation between them.
 ///
-/// The value is in seconds.
-pub const DEFAULT_IDLE_TIMEOUT: u64 = 30; // 30secs
+/// The value is in milliseconds.
+pub const DEFAULT_IDLE_TIMEOUT_MSEC: u64 = 30_000; // 30secs
 /// Default Interval to send keep-alives if we are idling so that the peer does not disconnect from
 /// us declaring us offline. If none is supplied we'll default to the documented constant.
 ///
-/// The value is in seconds.
-pub const DEFAULT_KEEP_ALIVE_INTERVAL: u32 = 10; // 10secs
+/// The value is in milliseconds.
+pub const DEFAULT_KEEP_ALIVE_INTERVAL_MSEC: u32 = 10_000; // 10secs
 
 /// Main Crust instance to communicate with Crust
 pub struct Crust {
@@ -93,11 +93,14 @@ impl Crust {
             .max_msg_size_allowed
             .map(|size| size as usize)
             .unwrap_or(DEFAULT_MAX_ALLOWED_MSG_SIZE);
-        let idle_timeout = self.cfg.idle_timeout.unwrap_or(DEFAULT_IDLE_TIMEOUT);
+        let idle_timeout = self
+            .cfg
+            .idle_timeout_msec
+            .unwrap_or(DEFAULT_IDLE_TIMEOUT_MSEC);
         let keep_alive_interval = self
             .cfg
-            .keep_alive_interval
-            .unwrap_or(DEFAULT_KEEP_ALIVE_INTERVAL);
+            .keep_alive_interval_msec
+            .unwrap_or(DEFAULT_KEEP_ALIVE_INTERVAL_MSEC);
 
         let tx = self.event_tx.clone();
 
@@ -124,8 +127,8 @@ impl Crust {
                 let transport_config = unwrap!(Arc::get_mut(&mut our_cfg.transport_config));
                 // TODO test that this is sent only over the uni-stream to the peer not on the uni
                 // stream from the peer
-                transport_config.idle_timeout = idle_timeout * 1000;
-                transport_config.keep_alive_interval = keep_alive_interval * 1000;
+                transport_config.idle_timeout = idle_timeout;
+                transport_config.keep_alive_interval = keep_alive_interval;
             }
 
             let mut ep_builder = quinn::Endpoint::new();


### PR DESCRIPTION
* This quinn version uses miliseconds rather than seconds for time based values;
* it has fixed packet timeout handling which used to stall message
  passing;
* Connection::close() now consumes connection, but there's no need to
  explicitly close the connection as that will happen when `Connection`
  object is dropped.